### PR TITLE
Allow custom injector creation

### DIFF
--- a/jukito/src/main/java/org/jukito/JukitoRunner.java
+++ b/jukito/src/main/java/org/jukito/JukitoRunner.java
@@ -90,8 +90,7 @@ public class JukitoRunner extends BlockJUnit4ClassRunner {
      * @param testModule the test module
      * @return a newly created injector
      */
-    protected Injector createInjector(TestModule testModule)
-    {
+    protected Injector createInjector(TestModule testModule) {
         return Guice.createInjector(testModule);
     }
 


### PR DESCRIPTION
I recently started using [Netflix Governator](https://github.com/Netflix/governator), and have been trying to get it working with Jukito, but have had some issues.

This PR makes it possible to use governator by allowing `JukitoRunner` to be extended and `createInjector` to be overridden. For example, I've overridden it like this:

```
@Override
protected Injector createInjector(TestModule testModule)
{
    LifecycleInjector lifecycleInjector = LifecycleInjector.builder()
                            .withBootstrapModule(new MyCustomBootstrapModule())
                            .withAdditionalModules(testModule)
                            .build();

    Injector injector = lifecycleInjector.createInjector();
    lifeCycleManager = injector.getInstance(LifecycleManager.class); // start/stop this later
    return injector;
}
```

I know that `JukitoRunner` has a constructor that takes an injector, but if this constructor is used, then `ensureInjector` will not run.
