### PR TITLE
Don't call ensureInjector() on initialization

### DIFF
--- a/jukito/src/main/java/org/jukito/JukitoRunner.java
+++ b/jukito/src/main/java/org/jukito/JukitoRunner.java
@@ -73,7 +73,6 @@ public class JukitoRunner extends BlockJUnit4ClassRunner {
     public JukitoRunner(Class<?> klass) throws InitializationError,
             InvocationTargetException, InstantiationException, IllegalAccessException {
         super(klass);
-        ensureInjector();
     }
 
     public JukitoRunner(Class<?> klass, Injector injector) throws InitializationError,


### PR DESCRIPTION
I'm running into a problem (not caused by Jukito) where the injection of a test has side-effects and causes other tests to fail.

In my case, the test will not actually run, because it will be excluded by JUnit Filtering, but the mere presence of the test causes the JukitoRunner to be instantiated, thereby causing ensureInjector() to be called, and triggering the side-effect.

In a perfect world, a TestModule would not have side-effects, but in practice I think the behavior should be that injection only happens if the test actually runs. Since ensureInjector() is called in many other places, I believe this change is safe and will give the desired behavior.

Please let me know what you think,
--Jason.