### PR TITLE
autoBindMocks property on UseModules annotation parent inner test module discovery

### DIFF
--- a/jukito/src/main/java/org/jukito/InjectedStatement.java
+++ b/jukito/src/main/java/org/jukito/InjectedStatement.java
@@ -55,18 +55,31 @@ class InjectedStatement extends Statement {
         UseModules useModules = javaMethod.getAnnotation(UseModules.class);
         if (useModules != null) {
             Class<? extends Module>[] moduleClasses = useModules.value();
+            final boolean autoBindMocks = useModules.autoBindMocks();
             final Module[] modules = new Module[moduleClasses.length];
             for (int i = 0; i < modules.length; i++) {
                 modules[i] = moduleClasses[i].newInstance();
             }
-            JukitoModule jukitoModule = new JukitoModule() {
-                @Override
-                protected void configureTest() {
-                    for (Module m : modules) {
-                        install(m);
+            TestModule jukitoModule;
+            if (autoBindMocks) {
+                jukitoModule = new JukitoModule() {
+                    @Override
+                    protected void configureTest() {
+                        for (Module m : modules) {
+                            install(m);
+                        }
                     }
-                }
-            };
+                };
+            } else {
+                jukitoModule = new TestModule() {
+                    @Override
+                    protected void configureTest() {
+                        for (Module m : modules) {
+                            install(m);
+                        }
+                    }
+                };
+            }
             methodInjector = Guice.createInjector(jukitoModule);
         }
 

--- a/jukito/src/main/java/org/jukito/JukitoRunner.java
+++ b/jukito/src/main/java/org/jukito/JukitoRunner.java
@@ -167,9 +167,10 @@ public class JukitoRunner extends BlockJUnit4ClassRunner {
         return modules;
     }
 
-    private TestModule getInnerClassModule(final Class<?> testClass) throws InstantiationException, IllegalAccessException {
+    private TestModule getInnerClassModule(final Class<?> testClass)
+            throws InstantiationException, IllegalAccessException {
         Class<?> currentClass = testClass;
-        while(currentClass != null) {
+        while (currentClass != null) {
             for (final Class<?> innerClass : currentClass.getDeclaredClasses()) {
                 if (TestModule.class.isAssignableFrom(innerClass)) {
                     return (TestModule) innerClass.newInstance();
@@ -194,7 +195,8 @@ public class JukitoRunner extends BlockJUnit4ClassRunner {
         return autoBindMocks;
     }
 
-    private TestModule createJukitoModule(final Iterable<Class<? extends Module>> moduleClasses, final boolean autoBindMocks) {
+    private TestModule createJukitoModule(final Iterable<Class<? extends Module>> moduleClasses,
+                                          final boolean autoBindMocks) {
         if (autoBindMocks) {
             return new JukitoModule() {
                 @Override

--- a/jukito/src/main/java/org/jukito/JukitoRunner.java
+++ b/jukito/src/main/java/org/jukito/JukitoRunner.java
@@ -67,7 +67,6 @@ import java.util.Set;
  */
 public class JukitoRunner extends BlockJUnit4ClassRunner {
 
-    private static final boolean useAutomockingIfNoEnvironmentFound = true;
     private Injector injector;
 
     public JukitoRunner(Class<?> klass) throws InitializationError,
@@ -124,24 +123,17 @@ public class JukitoRunner extends BlockJUnit4ClassRunner {
 
     private TestModule getTestModule(Class<?> testClass) throws InstantiationException, IllegalAccessException {
         Set<Class<? extends Module>> useModuleClasses = getUseModuleClasses(testClass);
+        final boolean autoBindMocks = getAutoBindMocksValue(testClass);
         if (!useModuleClasses.isEmpty()) {
-            return createJukitoModule(useModuleClasses);
+            return createJukitoModule(useModuleClasses, autoBindMocks);
         }
 
-        TestModule testModule = null;
-        for (Class<?> innerClass : testClass.getDeclaredClasses()) {
-            if (TestModule.class.isAssignableFrom(innerClass)) {
-                assert testModule == null :
-                        "More than one TestModule inner class found within test class \""
-                                + testClass.getName() + "\".";
-                testModule = (TestModule) innerClass.newInstance();
-            }
-        }
+        final TestModule testModule = getInnerClassModule(testClass);
         if (testModule != null) {
             return testModule;
         }
 
-        if (useAutomockingIfNoEnvironmentFound) {
+        if (autoBindMocks) {
             return new JukitoModule() {
                 @Override
                 protected void configureTest() {
@@ -175,19 +167,61 @@ public class JukitoRunner extends BlockJUnit4ClassRunner {
         return modules;
     }
 
-    private JukitoModule createJukitoModule(final Iterable<Class<? extends Module>> moduleClasses) {
-        return new JukitoModule() {
-            @Override
-            protected void configureTest() {
-                for (Class<? extends Module> mClass : moduleClasses) {
-                    try {
-                        install(mClass.newInstance());
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
+    private TestModule getInnerClassModule(final Class<?> testClass) throws InstantiationException, IllegalAccessException {
+        Class<?> currentClass = testClass;
+        while(currentClass != null) {
+            for (final Class<?> innerClass : currentClass.getDeclaredClasses()) {
+                if (TestModule.class.isAssignableFrom(innerClass)) {
+                    return (TestModule) innerClass.newInstance();
                 }
             }
-        };
+            currentClass = currentClass.getSuperclass();
+        }
+        return null;
+    }
+
+    private boolean getAutoBindMocksValue(final Class<?> testClass) {
+        boolean autoBindMocks = true;
+        Class<?> currentClass = testClass;
+        while (currentClass != null) {
+            final UseModules useModules = currentClass.getAnnotation(UseModules.class);
+            if (useModules != null) {
+                autoBindMocks = useModules.autoBindMocks();
+                break;
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+        return autoBindMocks;
+    }
+
+    private TestModule createJukitoModule(final Iterable<Class<? extends Module>> moduleClasses, final boolean autoBindMocks) {
+        if (autoBindMocks) {
+            return new JukitoModule() {
+                @Override
+                protected void configureTest() {
+                    for (Class<? extends Module> mClass : moduleClasses) {
+                        try {
+                            install(mClass.newInstance());
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+            };
+        } else {
+            return new TestModule() {
+                @Override
+                protected void configureTest() {
+                    for (Class<? extends Module> mClass : moduleClasses) {
+                        try {
+                            install(mClass.newInstance());
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+            };
+        }
     }
 
     @Override

--- a/jukito/src/main/java/org/jukito/UseModules.java
+++ b/jukito/src/main/java/org/jukito/UseModules.java
@@ -56,5 +56,8 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface UseModules {
+
     Class<? extends Module>[] value();
+
+    boolean autoBindMocks() default true;
 }

--- a/jukito/src/test/java/org/jukito/AutoBindMocksDisabledTest.java
+++ b/jukito/src/test/java/org/jukito/AutoBindMocksDisabledTest.java
@@ -1,0 +1,60 @@
+package org.jukito;
+
+import com.google.inject.PrivateModule;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import javax.inject.Inject;
+
+class MyModule extends PrivateModule {
+
+    @Override
+    protected void configure() {
+        bind(ExposedClass.class);
+        bind(SomeInterface.class).to(NotAMock.class);
+        expose(ExposedClass.class);
+    }
+}
+
+interface SomeInterface {
+    void doSomething();
+}
+
+class NotAMock implements SomeInterface {
+
+    @Override
+    public void doSomething() {
+
+    }
+}
+
+class ExposedClass {
+
+    private SomeInterface instance;
+
+    @Inject
+    ExposedClass(final SomeInterface instance) {
+        this.instance = instance;
+    }
+
+    SomeInterface getInstance() {
+        return instance;
+    }
+}
+
+/**
+ * NOTE: If autoBindMocks is true, this test will fail because SomeInterface will be auto bound
+ * to a mock and the binding will conflict with private module's binding
+ */
+@RunWith(JukitoRunner.class)
+@UseModules(value = MyModule.class, autoBindMocks = false)
+public class AutoBindMocksDisabledTest {
+
+    @Test
+    public void testSomething(final ExposedClass clazz) throws Exception {
+        Assert.assertFalse(Mockito.mockingDetails(clazz).isMock());
+        Assert.assertFalse(Mockito.mockingDetails(clazz.getInstance()).isMock());
+    }
+}

--- a/jukito/src/test/java/org/jukito/AutoBindMocksDisabledTest.java
+++ b/jukito/src/test/java/org/jukito/AutoBindMocksDisabledTest.java
@@ -1,56 +1,88 @@
+/**
+ * Copyright 2013 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.jukito;
 
 import com.google.inject.PrivateModule;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.mockito.Mockito;
 
 import javax.inject.Inject;
 
-class MyModule extends PrivateModule {
-
-    @Override
-    protected void configure() {
-        bind(ExposedClass.class);
-        bind(SomeInterface.class).to(NotAMock.class);
-        expose(ExposedClass.class);
-    }
-}
-
-interface SomeInterface {
-    void doSomething();
-}
-
-class NotAMock implements SomeInterface {
-
-    @Override
-    public void doSomething() {
-
-    }
-}
-
-class ExposedClass {
-
-    private SomeInterface instance;
-
-    @Inject
-    ExposedClass(final SomeInterface instance) {
-        this.instance = instance;
-    }
-
-    SomeInterface getInstance() {
-        return instance;
-    }
-}
-
 /**
+ * Tests behavior of autoBindMocks property on UseModules annotation.
  * NOTE: If autoBindMocks is true, this test will fail because SomeInterface will be auto bound
  * to a mock and the binding will conflict with private module's binding
  */
 @RunWith(JukitoRunner.class)
-@UseModules(value = MyModule.class, autoBindMocks = false)
+@UseModules(value = AutoBindMocksDisabledTest.MyModule.class, autoBindMocks = false)
 public class AutoBindMocksDisabledTest {
+
+    /**
+     * Guice PrivateModule for testing.
+     */
+    public static final class MyModule extends PrivateModule {
+
+        @Override
+        protected void configure() {
+            bind(ExposedClass.class);
+            bind(SomeInterface.class).to(NotAMock.class);
+            expose(ExposedClass.class);
+        }
+    }
+
+    /**
+     * Test Interface that will be auto mocked if autoBindMocks is set to true.
+     */
+    public interface SomeInterface {
+        void doSomething();
+    }
+
+    /**
+     * When autoBindMocks is false, an instance of this type will be bound
+     * to SomeInterface from the PrivateModule.
+     */
+    public static final class NotAMock implements SomeInterface {
+
+        @Override
+        public void doSomething() {
+        }
+    }
+
+    /**
+     * Class which injects either the automock or the concrete instance
+     * depending on the autoBindMocks property.
+     */
+    public static final class ExposedClass {
+
+        private SomeInterface instance;
+
+        @Inject
+        ExposedClass(final SomeInterface instance) {
+            this.instance = instance;
+        }
+
+        SomeInterface getInstance() {
+            return instance;
+        }
+    }
 
     @Test
     public void testSomething(final ExposedClass clazz) throws Exception {

--- a/jukito/src/test/java/org/jukito/ParentClassInnerClassModuleDiscoveryTest.java
+++ b/jukito/src/test/java/org/jukito/ParentClassInnerClassModuleDiscoveryTest.java
@@ -1,5 +1,20 @@
-package org.jukito;
+/**
+ * Copyright 2013 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
+package org.jukito;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -8,19 +23,11 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-class ParentTestClass {
-
-    public static final class MyModule extends JukitoModule {
-
-        @Override
-        protected void configureTest() {
-            bindManyInstances(String.class, "Hello", "World");
-        }
-    }
-}
-
+/**
+ * Test which ensures that nested TestModules in parent classes are discovered by the JukitoRunner.
+ */
 @RunWith(JukitoRunner.class)
-public class ParentClassInnerClassModuleDiscoveryTest extends ParentTestClass {
+public class ParentClassInnerClassModuleDiscoveryTest extends SampleParentTestClassWithInnerTestModule {
 
     private static final AtomicInteger numberOfTestRuns = new AtomicInteger(0);
 
@@ -30,7 +37,7 @@ public class ParentClassInnerClassModuleDiscoveryTest extends ParentTestClass {
     }
 
     @Test
-    public void testSomething(@All final String bindingFromParentClassInnerModule) throws Exception {
+    public void testSomething(@All final String bindingsFromParent) throws Exception {
         numberOfTestRuns.incrementAndGet();
     }
 }

--- a/jukito/src/test/java/org/jukito/ParentClassInnerClassModuleDiscoveryTest.java
+++ b/jukito/src/test/java/org/jukito/ParentClassInnerClassModuleDiscoveryTest.java
@@ -1,0 +1,36 @@
+package org.jukito;
+
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+class ParentTestClass {
+
+    public static final class MyModule extends JukitoModule {
+
+        @Override
+        protected void configureTest() {
+            bindManyInstances(String.class, "Hello", "World");
+        }
+    }
+}
+
+@RunWith(JukitoRunner.class)
+public class ParentClassInnerClassModuleDiscoveryTest extends ParentTestClass {
+
+    private static final AtomicInteger numberOfTestRuns = new AtomicInteger(0);
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        Assert.assertEquals(2, numberOfTestRuns.get());
+    }
+
+    @Test
+    public void testSomething(@All final String bindingFromParentClassInnerModule) throws Exception {
+        numberOfTestRuns.incrementAndGet();
+    }
+}

--- a/jukito/src/test/java/org/jukito/SampleParentTestClassWithInnerTestModule.java
+++ b/jukito/src/test/java/org/jukito/SampleParentTestClassWithInnerTestModule.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2013 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.jukito;
+
+/**
+ * Sample Parent Test Class which binds 2 string instances for use by
+ * the {@link ParentClassInnerClassModuleDiscoveryTest}.
+ */
+public class SampleParentTestClassWithInnerTestModule {
+
+    /**
+     * Sample JukitoModule which binds 2 String instances.
+     * The Instances will be injected to an {@code @All} test and counted to verify that
+     * this module is discovered by the JukitoRunner.
+     */
+    public static final class MyModule extends JukitoModule {
+
+        @Override
+        protected void configureTest() {
+            bindManyInstances(String.class, "Hello", "World");
+        }
+    }
+}


### PR DESCRIPTION
Hi there,

I had some trouble using Jukito with Guice private modules and it seems like the fix is pretty simple--use a TestModule instead of a JukitoModule to prevent autobinding mocks. I figured adding a property to the UseModules annotation would be a pretty quick fix. 

Also I improved the inner test module discovery heuristic to search parent classes for the test module as well as the running test class.

Tests for these changes are also included